### PR TITLE
Redact the nelson.session cookie in debug mode

### DIFF
--- a/src/github.com/verizon/nelson/log_filter.go
+++ b/src/github.com/verizon/nelson/log_filter.go
@@ -1,0 +1,46 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2017 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package main
+
+import (
+	"fmt"
+	"github.com/parnurzeal/gorequest"
+	"regexp"
+)
+
+var sanitizer = regexp.MustCompile("nelson.session=(.*)")
+
+type FilteredLog struct {
+	logger gorequest.Logger
+}
+
+func FilterLog(logger gorequest.Logger) *FilteredLog {
+	return &FilteredLog{logger: logger}
+}
+
+func (f FilteredLog) SetPrefix(s string) {
+	f.logger.SetPrefix(s)
+}
+
+func (f FilteredLog) Printf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v)
+	f.logger.Println(sanitizer.ReplaceAllString(s, "nelson.session=<redacted>"))
+}
+
+func (f FilteredLog) Println(v ...interface{}) {
+	f.logger.Println(v)
+}

--- a/src/github.com/verizon/nelson/main.go
+++ b/src/github.com/verizon/nelson/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 	"gopkg.in/urfave/cli.v1"
 	"io/ioutil"
+	"log"
 	"os"
 	"regexp"
 	"strconv"
@@ -43,6 +44,7 @@ func main() {
 	app.EnableBashCompletion = true
 
 	http := gorequest.New()
+	http.SetLogger(FilterLog(log.New(os.Stderr, "[gorequest]", log.LstdFlags)))
 	pi := ProgressIndicator()
 
 	// switches for the cli

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -52,7 +52,7 @@
 		{
 			"importpath": "github.com/parnurzeal/gorequest",
 			"repository": "https://github.com/parnurzeal/gorequest",
-			"revision": "ea779001e09326d30d455dbf37bc0d08c49941a2",
+			"revision": "5bf13be198787abbed057fb7c4007f372083a0f5",
 			"branch": "develop"
 		},
 		{

--- a/vendor/src/github.com/parnurzeal/gorequest/README.md
+++ b/vendor/src/github.com/parnurzeal/gorequest/README.md
@@ -242,7 +242,7 @@ Supposing you need retry 3 times, with 5 seconds between each attempt when gets 
 ```go
 request := gorequest.New()
 resp, body, errs := request.Get("http://example.com/").
-                    Retry(3, 5 * time.seconds, http.StatusBadRequest, http.StatusInternalServerError).
+                    Retry(3, 5 * time.Second, http.StatusBadRequest, http.StatusInternalServerError).
                     End()
 ```
 

--- a/vendor/src/github.com/parnurzeal/gorequest/gorequest.go
+++ b/vendor/src/github.com/parnurzeal/gorequest/gorequest.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -67,7 +68,7 @@ type SuperAgent struct {
 	BasicAuth         struct{ Username, Password string }
 	Debug             bool
 	CurlCommand       bool
-	logger            *log.Logger
+	logger            Logger
 	Retryable         struct {
 		RetryableStatus []int
 		RetryerTime     time.Duration
@@ -124,7 +125,7 @@ func (s *SuperAgent) SetCurlCommand(enable bool) *SuperAgent {
 	return s
 }
 
-func (s *SuperAgent) SetLogger(logger *log.Logger) *SuperAgent {
+func (s *SuperAgent) SetLogger(logger Logger) *SuperAgent {
 	s.logger = logger
 	return s
 }
@@ -1088,14 +1089,28 @@ func (s *SuperAgent) getResponseBytes() (Response, []byte, []error) {
 
 func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 	var (
-		req *http.Request
-		err error
+		req           *http.Request
+		contentType   string // This is only set when the request body content is non-empty.
+		contentReader io.Reader
+		err           error
 	)
 
 	if s.Method == "" {
 		return nil, errors.New("No method specified")
 	}
 
+	// !!! Important Note !!!
+	//
+	// Throughout this region, contentReader and contentType are only set when
+	// the contents will be non-empty.
+	// This is done avoid ever sending a non-nil request body with nil contents
+	// to http.NewRequest, because it contains logic which dependends on
+	// whether or not the body is "nil".
+	//
+	// See PR #136 for more information:
+	//
+	//     https://github.com/parnurzeal/gorequest/pull/136
+	//
 	if s.TargetType == "json" {
 		// If-case to give support to json array. we check if
 		// 1) Map only: send it as json map from s.Data
@@ -1108,12 +1123,10 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 		} else if len(s.SliceData) != 0 {
 			contentJson, _ = json.Marshal(s.SliceData)
 		}
-		contentReader := bytes.NewReader(contentJson)
-		req, err = http.NewRequest(s.Method, s.Url, contentReader)
-		if err != nil {
-			return nil, err
+		if contentJson != nil {
+			contentReader = bytes.NewReader(contentJson)
+			contentType = "application/json"
 		}
-		req.Header.Set("Content-Type", "application/json")
 	} else if s.TargetType == "form" || s.TargetType == "form-data" || s.TargetType == "urlencoded" {
 		var contentForm []byte
 		if s.BounceToRawString || len(s.SliceData) != 0 {
@@ -1122,22 +1135,25 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 			formData := changeMapToURLValues(s.Data)
 			contentForm = []byte(formData.Encode())
 		}
-		contentReader := bytes.NewReader(contentForm)
-		req, err = http.NewRequest(s.Method, s.Url, contentReader)
-		if err != nil {
-			return nil, err
+		if len(contentForm) != 0 {
+			contentReader = bytes.NewReader(contentForm)
+			contentType = "application/x-www-form-urlencoded"
 		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	} else if s.TargetType == "text" {
-		req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
-		req.Header.Set("Content-Type", "text/plain")
+		if len(s.RawString) != 0 {
+			contentReader = strings.NewReader(s.RawString)
+			contentType = "text/plain"
+		}
 	} else if s.TargetType == "xml" {
-		req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
-		req.Header.Set("Content-Type", "application/xml")
+		if len(s.RawString) != 0 {
+			contentReader = strings.NewReader(s.RawString)
+			contentType = "application/xml"
+		}
 	} else if s.TargetType == "multipart" {
-
-		var buf bytes.Buffer
-		mw := multipart.NewWriter(&buf)
+		var (
+			buf = &bytes.Buffer{}
+			mw  = multipart.NewWriter(buf)
+		)
 
 		if s.BounceToRawString {
 			fieldName, ok := s.Header["data_fieldname"]
@@ -1146,6 +1162,7 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 			}
 			fw, _ := mw.CreateFormField(fieldName)
 			fw.Write([]byte(s.RawString))
+			contentReader = buf
 		}
 
 		if len(s.Data) != 0 {
@@ -1156,6 +1173,7 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 					fw.Write([]byte(value))
 				}
 			}
+			contentReader = buf
 		}
 
 		if len(s.SliceData) != 0 {
@@ -1174,6 +1192,7 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 				return nil, err
 			}
 			fw.Write(contentJson)
+			contentReader = buf
 		}
 
 		// add the files
@@ -1182,16 +1201,26 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 				fw, _ := mw.CreateFormFile(file.Fieldname, file.Filename)
 				fw.Write(file.Data)
 			}
+			contentReader = buf
 		}
 
 		// close before call to FormDataContentType ! otherwise its not valid multipart
 		mw.Close()
 
-		req, err = http.NewRequest(s.Method, s.Url, &buf)
-		req.Header.Set("Content-Type", mw.FormDataContentType())
+		if contentReader != nil {
+			contentType = mw.FormDataContentType()
+		}
 	} else {
 		// let's return an error instead of an nil pointer exception here
 		return nil, errors.New("TargetType '" + s.TargetType + "' could not be determined")
+	}
+
+	if req, err = http.NewRequest(s.Method, s.Url, contentReader); err != nil {
+		return nil, err
+	}
+
+	if len(contentType) != 0 {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	for k, v := range s.Header {

--- a/vendor/src/github.com/parnurzeal/gorequest/gorequest_test.go
+++ b/vendor/src/github.com/parnurzeal/gorequest/gorequest_test.go
@@ -1063,6 +1063,7 @@ func TestMultipartRequest(t *testing.T) {
 		Type("multipart").
 		Query("query1=test").
 		Query("query2=test").
+		Send("foo").
 		End()
 
 	New().Post(ts.URL + case5_send_struct).

--- a/vendor/src/github.com/parnurzeal/gorequest/logger.go
+++ b/vendor/src/github.com/parnurzeal/gorequest/logger.go
@@ -1,0 +1,7 @@
+package gorequest
+
+type Logger interface {
+	SetPrefix(string)
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}


### PR DESCRIPTION
If the need arises, we could add another flag to really show the session cookie.  (For now, it's in `~/.nelson/config.yml`).  This should be enough to stop the accidental pastes.