### PR TITLE
Correctly analyze the response of manual registrations

### DIFF
--- a/src/github.com/verizon/nelson/stack.go
+++ b/src/github.com/verizon/nelson/stack.go
@@ -59,7 +59,7 @@ func RegisterManualDeployment(
 		return "", errs
 	}
 
-	if r.StatusCode/100 != 3 {
+	if r.StatusCode/100 != 2 {
 		resp := string(body[:])
 		errs = append(errs, errors.New("Unexpected response from Nelson server"))
 		return resp, errs


### PR DESCRIPTION
The endpoint redirects, and the client follows the redirect. We should be
looking for a 2xx response, not a 3xx response.

In some vendor upgrade somewhere, we lost the propagation of the session cookie.
Set the redirect policy so we send it if we're redirecting to the same host.