### PR TITLE
Fix for install on linux

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,7 @@ else
 fi
 
 function fetch_from_github(){
-  curl -s https://api.github.com/repos/verizon/nelson-cli/releases | grep browser_download_url | head -n 2 | cut -d '"' -f 4 | grep $PLATFORM
+  curl -s https://api.github.com/repos/verizon/nelson-cli/releases | grep browser_download_url | head -n 4 | cut -d '"' -f 4 | grep $PLATFORM
 }
 
 ARTIFACT_URL=$(fetch_from_github | grep -v 'sha1')


### PR DESCRIPTION
browser_download_url comes in pair:

> "browser_download_url": "https://github.com/Verizon/nelson-cli/releases/download/0.9.36/nelson-darwin-amd64-0.9.36.tar.gz"
"browser_download_url": "https://github.com/Verizon/nelson-cli/releases/download/0.9.36/nelson-darwin-amd64-0.9.36.tar.gz.sha1"
"browser_download_url": "https://github.com/Verizon/nelson-cli/releases/download/0.9.36/nelson-linux-amd64-0.9.36.tar.gz"
"browser_download_url": "https://github.com/Verizon/nelson-cli/releases/download/0.9.36/nelson-linux-amd64-0.9.36.tar.gz.sha1"

so if osx is first on linux files aren't find and installer exits silently.